### PR TITLE
Remove ads between episodes and other minor enhancements

### DIFF
--- a/dist/kantv-helper.user.js
+++ b/dist/kantv-helper.user.js
@@ -120,10 +120,6 @@ function today() {
     });
 }
 
-function muteElement(elem, bool) {
-  elem.muted = bool;
-}
-
 function adMandatory() {
   return getVueInstance('#vjs-mandatory-advertisement')
     .then(vue => {
@@ -306,7 +302,7 @@ function removeAd() {
 
 
 window.onload = async (event) => {
-  // Fire skip adMandatory again upon change in episode name
+  // Fire skip removeAd again upon change in episode name
   let episode = document.getElementById("cPartNum");
   episode.addEventListener("DOMSubtreeModified", () => { removeAd(); });
 };

--- a/dist/kantv-helper.user.js
+++ b/dist/kantv-helper.user.js
@@ -96,33 +96,42 @@ function qrCode() {
 }
 
 function today() {
-    return getVueInstance('.vjs-jinriaozhou')
-        .then(vue => {
-            /* request success */
-            vue.followedSuccess = true;
-            vue.visible = false;
-            // the following line will be done by changing `type`
-            // vue.$emit('update:displayState', false);
-            vue.$emit('update:coverAndProhibitPlay', false);
-            vue.initState.end ||
-            vue.$emit('update:initState', {
-                start: true,
-                end: true,
-                skipOtherOptions: true,
-            });
-
-            /* before destroy */
-            clearTimeout(vue.requestSubscribeTimer);
-            clearTimeout(vue.teseTimer);
-        })
-        .catch(err => {
-            console.warn('qr vue is not detected.');
+  return getVueInstance('.vjs-jinriaozhou')
+    .then(vue => {
+      /* request success */
+      vue.followedSuccess = true;
+      vue.visible = false;
+      // the following line will be done by changing `type`
+      // vue.$emit('update:displayState', false);
+      vue.$emit('update:coverAndProhibitPlay', false);
+      vue.initState.end ||
+        vue.$emit('update:initState', {
+          start: true,
+          end: true,
+          skipOtherOptions: true,
         });
+
+      /* before destroy */
+      clearTimeout(vue.requestSubscribeTimer);
+      clearTimeout(vue.teseTimer);
+    })
+    .catch(err => {
+      console.warn('qr vue is not detected.');
+    });
+}
+
+function muteElement(elem, bool) {
+  elem.muted = bool;
 }
 
 function adMandatory() {
   return getVueInstance('#vjs-mandatory-advertisement')
     .then(vue => {
+      // Ensure that the audio for the ad is muted
+      detectElement(".vjs-mandatory-advertisement__video").then(element => {
+        element.muted = true;
+      })
+
       if (!vue.advertising) {
         console.log('no ad on this video.');
         return;
@@ -131,12 +140,7 @@ function adMandatory() {
       // allow close mandatory ad
       vue.advertising.closeMandatory = true;
 
-      // force finish the first ad
-      vue.$set(vue, 'currentAdvertisingTime', parseFloat('Infinity'));
-
-      vue.advertising.closeMandatory = true;
-
-      detectElement('#vjs-mandatory-advertisement__close').then((element)=>{
+      detectElement('#vjs-mandatory-advertisement__close').then((element) => {
         element.click();
       })
       console.log("Ad removed");
@@ -189,17 +193,17 @@ function adCorner() {
 }
 
 function styles() {
-    let styleEl = document.createElement('style');
-    document.head.appendChild(styleEl);
-    let styleSheet = styleEl.sheet;
-    [
-        '.adcontainer',
-        '.mtg-client_left',
-        '.mtg-client_right',
-        '.a-card-item',
-    ].forEach(selector => {
-        styleSheet.insertRule(`${selector}{display:none!important;}`);
-    });
+  let styleEl = document.createElement('style');
+  document.head.appendChild(styleEl);
+  let styleSheet = styleEl.sheet;
+  [
+    '.adcontainer',
+    '.mtg-client_left',
+    '.mtg-client_right',
+    '.a-card-item',
+  ].forEach(selector => {
+    styleSheet.insertRule(`${selector}{display:none!important;}`);
+  });
 }
 
 function keyControls(vjs) {
@@ -277,7 +281,7 @@ function keyControls(vjs) {
   });
 }
 
-function removeAd(){
+function removeAd() {
   adCorner();
   adPause();
   adMandatory();
@@ -302,7 +306,7 @@ function removeAd(){
 
 
 window.onload = async (event) => {
-    // Fire skip adMandatory again upon change in episode name
-    let episode = document.getElementById("cPartNum");
-    episode.addEventListener("DOMSubtreeModified", ()=>{removeAd();});
+  // Fire skip adMandatory again upon change in episode name
+  let episode = document.getElementById("cPartNum");
+  episode.addEventListener("DOMSubtreeModified", () => { removeAd(); });
 };

--- a/dist/kantv-helper.user.js
+++ b/dist/kantv-helper.user.js
@@ -134,14 +134,12 @@ function adMandatory() {
       // force finish the first ad
       vue.$set(vue, 'currentAdvertisingTime', parseFloat('Infinity'));
 
-      // remove all mandatory ads
-      let adIndexes = Object.keys(vue.advertising.mandatory);
-      for (let i = 0; i < adIndexes.length; i++) {
-        let mandatory = vue.advertising.mandatory[adIndexes[i]];
-        if (mandatory) {
-          mandatory.length = 0;
-        }
-      }
+      vue.advertising.closeMandatory = true;
+
+      detectElement('#vjs-mandatory-advertisement__close').then((element)=>{
+        element.click();
+      })
+      console.log("Ad removed");
     })
     .catch(err => {
       console.warn('mandatory ad vue is not detected.');
@@ -297,3 +295,10 @@ function keyControls(vjs) {
       console.warn(err);
     });
 })();
+
+
+window.onload = async (event) => {
+    // Fire skip adMandatory again upon change in episode name
+    let episode = document.getElementById("cPartNum");
+    episode.addEventListener("DOMSubtreeModified", ()=>{adMandatory();});
+};

--- a/dist/kantv-helper.user.js
+++ b/dist/kantv-helper.user.js
@@ -277,13 +277,17 @@ function keyControls(vjs) {
   });
 }
 
-(() => {
+function removeAd(){
   adCorner();
   adPause();
   adMandatory();
   qrCode();
   today();
   styles();
+}
+
+(() => {
+  removeAd();
 })();
 
 (() => {
@@ -300,5 +304,5 @@ function keyControls(vjs) {
 window.onload = async (event) => {
     // Fire skip adMandatory again upon change in episode name
     let episode = document.getElementById("cPartNum");
-    episode.addEventListener("DOMSubtreeModified", ()=>{adMandatory();});
+    episode.addEventListener("DOMSubtreeModified", ()=>{removeAd();});
 };

--- a/dist/kantv-helper.user.js
+++ b/dist/kantv-helper.user.js
@@ -96,28 +96,28 @@ function qrCode() {
 }
 
 function today() {
-  return getVueInstance('.vjs-jinriaozhou')
-    .then(vue => {
-      /* request success */
-      vue.followedSuccess = true;
-      vue.visible = false;
-      // the following line will be done by changing `type`
-      // vue.$emit('update:displayState', false);
-      vue.$emit('update:coverAndProhibitPlay', false);
-      vue.initState.end ||
-        vue.$emit('update:initState', {
-          start: true,
-          end: true,
-          skipOtherOptions: true,
-        });
+    return getVueInstance('.vjs-jinriaozhou')
+        .then(vue => {
+            /* request success */
+            vue.followedSuccess = true;
+            vue.visible = false;
+            // the following line will be done by changing `type`
+            // vue.$emit('update:displayState', false);
+            vue.$emit('update:coverAndProhibitPlay', false);
+            vue.initState.end ||
+            vue.$emit('update:initState', {
+                start: true,
+                end: true,
+                skipOtherOptions: true,
+            });
 
-      /* before destroy */
-      clearTimeout(vue.requestSubscribeTimer);
-      clearTimeout(vue.teseTimer);
-    })
-    .catch(err => {
-      console.warn('qr vue is not detected.');
-    });
+            /* before destroy */
+            clearTimeout(vue.requestSubscribeTimer);
+            clearTimeout(vue.teseTimer);
+        })
+        .catch(err => {
+            console.warn('qr vue is not detected.');
+        });
 }
 
 function adMandatory() {
@@ -126,7 +126,7 @@ function adMandatory() {
       // Ensure that the audio for the ad is muted
       detectElement(".vjs-mandatory-advertisement__video").then(element => {
         element.muted = true;
-      })
+      });
 
       if (!vue.advertising) {
         console.log('no ad on this video.');
@@ -138,8 +138,8 @@ function adMandatory() {
 
       detectElement('#vjs-mandatory-advertisement__close').then((element) => {
         element.click();
-      })
-      console.log("Ad removed");
+        console.log("Ad removed");
+      });
     })
     .catch(err => {
       console.warn('mandatory ad vue is not detected.');
@@ -189,17 +189,26 @@ function adCorner() {
 }
 
 function styles() {
-  let styleEl = document.createElement('style');
-  document.head.appendChild(styleEl);
-  let styleSheet = styleEl.sheet;
-  [
-    '.adcontainer',
-    '.mtg-client_left',
-    '.mtg-client_right',
-    '.a-card-item',
-  ].forEach(selector => {
-    styleSheet.insertRule(`${selector}{display:none!important;}`);
-  });
+    let styleEl = document.createElement('style');
+    document.head.appendChild(styleEl);
+    let styleSheet = styleEl.sheet;
+    [
+        '.adcontainer',
+        '.mtg-client_left',
+        '.mtg-client_right',
+        '.a-card-item',
+    ].forEach(selector => {
+        styleSheet.insertRule(`${selector}{display:none!important;}`);
+    });
+}
+
+function removeAd(){
+    adCorner();
+    adPause();
+    adMandatory();
+    qrCode();
+    today();
+    styles();
 }
 
 function keyControls(vjs) {
@@ -277,15 +286,6 @@ function keyControls(vjs) {
   });
 }
 
-function removeAd() {
-  adCorner();
-  adPause();
-  adMandatory();
-  qrCode();
-  today();
-  styles();
-}
-
 (() => {
   removeAd();
 })();
@@ -300,9 +300,8 @@ function removeAd() {
     });
 })();
 
-
 window.onload = async (event) => {
-  // Fire skip removeAd again upon change in episode name
+  // Fire skip adMandatory again upon change in episode name
   let episode = document.getElementById("cPartNum");
   episode.addEventListener("DOMSubtreeModified", () => { removeAd(); });
 };

--- a/dist/kantv-helper.user.js
+++ b/dist/kantv-helper.user.js
@@ -301,7 +301,7 @@ function keyControls(vjs) {
 })();
 
 window.onload = async (event) => {
-  // Fire skip adMandatory again upon change in episode name
+  // Fire removeAd again upon change in episode name
   let episode = document.getElementById("cPartNum");
   episode.addEventListener("DOMSubtreeModified", () => { removeAd(); });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import keyControls from './modules/key-controls';
 })();
 
 window.onload = async (event) => {
-  // Fire skip adMandatory again upon change in episode name
+  // Fire removeAd again upon change in episode name
   let episode = document.getElementById("cPartNum");
   episode.addEventListener("DOMSubtreeModified", () => { removeAd(); });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,9 @@
 import { detectElement } from './utils';
-import qrcode from './modules/qrcode';
-import today from './modules/today';
-import adMandatory from './modules/ad-mandatory';
-import adPause from './modules/ad-pause';
-import adCorner from './modules/ad-corner';
-import styles from './modules/styles';
+import removeAd from './modules/remove-ad'
 import keyControls from './modules/key-controls';
 
 (() => {
-  adCorner();
-  adPause();
-  adMandatory();
-  qrcode();
-  today();
-  styles();
+  removeAd();
 })();
 
 (() => {
@@ -25,3 +15,9 @@ import keyControls from './modules/key-controls';
       console.warn(err);
     });
 })();
+
+window.onload = async (event) => {
+  // Fire skip adMandatory again upon change in episode name
+  let episode = document.getElementById("cPartNum");
+  episode.addEventListener("DOMSubtreeModified", () => { removeAd(); });
+};

--- a/src/modules/ad-mandatory.js
+++ b/src/modules/ad-mandatory.js
@@ -3,6 +3,11 @@ import { getVueInstance } from '../utils';
 export default function adMandatory() {
   return getVueInstance('#vjs-mandatory-advertisement')
     .then(vue => {
+      // Ensure that the audio for the ad is muted
+      detectElement(".vjs-mandatory-advertisement__video").then(element => {
+        element.muted = true;
+      })
+
       if (!vue.advertising) {
         console.log('no ad on this video.');
         return;
@@ -11,17 +16,10 @@ export default function adMandatory() {
       // allow close mandatory ad
       vue.advertising.closeMandatory = true;
 
-      // force finish the first ad
-      vue.$set(vue, 'currentAdvertisingTime', parseFloat('Infinity'));
-
-      // remove all mandatory ads
-      let adIndexes = Object.keys(vue.advertising.mandatory);
-      for (let i = 0; i < adIndexes.length; i++) {
-        let mandatory = vue.advertising.mandatory[adIndexes[i]];
-        if (mandatory) {
-          mandatory.length = 0;
-        }
-      }
+      detectElement('#vjs-mandatory-advertisement__close').then((element) => {
+        element.click();
+      })
+      console.log("Ad removed");
     })
     .catch(err => {
       console.warn('mandatory ad vue is not detected.');

--- a/src/modules/ad-mandatory.js
+++ b/src/modules/ad-mandatory.js
@@ -1,4 +1,4 @@
-import { getVueInstance } from '../utils';
+import { getVueInstance, detectElement } from '../utils';
 
 export default function adMandatory() {
   return getVueInstance('#vjs-mandatory-advertisement')
@@ -18,8 +18,8 @@ export default function adMandatory() {
 
       detectElement('#vjs-mandatory-advertisement__close').then((element) => {
         element.click();
+        console.log("Ad removed");
       })
-      console.log("Ad removed");
     })
     .catch(err => {
       console.warn('mandatory ad vue is not detected.');

--- a/src/modules/remove-ad.js
+++ b/src/modules/remove-ad.js
@@ -1,9 +1,9 @@
-import qrcode from './modules/qrcode';
-import today from './modules/today';
-import adMandatory from './modules/ad-mandatory';
-import adPause from './modules/ad-pause';
-import adCorner from './modules/ad-corner';
-import styles from './modules/styles';
+import qrcode from './qrcode';
+import today from './today';
+import adMandatory from './ad-mandatory';
+import adPause from './ad-pause';
+import adCorner from './ad-corner';
+import styles from './styles';
 
 export default function removeAd(){
     adCorner();

--- a/src/modules/remove-ad.js
+++ b/src/modules/remove-ad.js
@@ -1,0 +1,15 @@
+import qrcode from './modules/qrcode';
+import today from './modules/today';
+import adMandatory from './modules/ad-mandatory';
+import adPause from './modules/ad-pause';
+import adCorner from './modules/ad-corner';
+import styles from './modules/styles';
+
+export default function removeAd(){
+    adCorner();
+    adPause();
+    adMandatory();
+    qrcode();
+    today();
+    styles();
+}


### PR DESCRIPTION
Added:
* Remove ads when switching between episodes, this is done via attaching a listener to the change in episode title (There must be a better way but I can't find them 😂)
* Audio for the ad is muted so that user won't hear that split second of ad.
* Add ad removal module which just calls the functions that was created, this is so it can be reused in ad removal between episodes

Modified:
* The way to skip ad is changed to making the ad skippable then automatically clicking on the skip button, this is done because the old implementation only skips the first ad, not the second ad.

Note:
* I only learned how to use `rollup` to build the dist .js so the commit order may be a bit hard to read..
* Version number is unchanged